### PR TITLE
Handling empty iterable case in element_type_checker().

### DIFF
--- a/pyvalid/validators/__iterable.py
+++ b/pyvalid/validators/__iterable.py
@@ -61,7 +61,7 @@ class IterableValidator(AbstractValidator):
             False:
                 If at least one element of the iterable is not of required type.
         """
-        valid = False
+        valid = True
         for element in val:
             valid = isinstance(element, elements_type)
             if not valid:

--- a/tests/test_iterable_validator.py
+++ b/tests/test_iterable_validator.py
@@ -25,6 +25,7 @@ class IterableValidatorTestCase(unittest.TestCase):
         self.assertTrue(validator([1, 3, 25, 14]))
         self.assertFalse(validator([3.56, 6.4532, 65.57, 5.546]))
         self.assertFalse(validator(['CPython', 'PyPy', 'Jython', 'Cython']))
+        self.assertTrue(validator([]))  # Ignore empty
 
         validator = IterableValidator(elements_type=float)
         self.assertFalse(validator([1, 3, 25, 14]))


### PR DESCRIPTION
IteratorValidator should not break when validating type and if the iterable is empty. So, returning True to not terminate the execution if the iterable is empty as empty_iterable_checker() already takes care of it.