### PR TITLE
Fixing signature of base __call__ method.

### DIFF
--- a/pyvalid/validators/__base.py
+++ b/pyvalid/validators/__base.py
@@ -27,7 +27,7 @@ class AbstractValidator(with_metaclass(ABCMeta, Validator)):
         raise NotImplementedError
 
     @abstractmethod
-    def __call__(self):
+    def __call__(self, val):
         raise NotImplementedError
 
     def __init__(self):


### PR DESCRIPTION
Updating signature of method 'AbstractValidator.__call__()' to match signature of all its derived classes __call__() method. 