### PR TITLE
Validate the data type of iterable and number.

### DIFF
--- a/pyvalid/validators/__iterable.py
+++ b/pyvalid/validators/__iterable.py
@@ -28,6 +28,26 @@ class IterableValidator(AbstractValidator):
     """
 
     @classmethod
+    def iterable_type_checker(cls, val, iterable_type):
+        """Checks if the iterable is of required data type.
+
+        Args:
+            val (Iterable):
+                Tensor whose type is to be validated.
+            iterable_type (type):
+                Expected data type of iterable.
+                Ex: list, tuple, dict.
+
+        Returns (bool):
+            True:
+                If the type of given iterable matches the required type.
+            False:
+                If the type of given iterable does not match the required type.
+
+        """
+        return type(val) == iterable_type
+
+    @classmethod
     def empty_checker(cls, val, empty_allowed):
         """Checks if the iterable is empty or not.
 
@@ -139,13 +159,16 @@ class IterableValidator(AbstractValidator):
     @accepts(object, empty_allowed=bool, element_type=(str, int, float),
              min_val=(int, float), max_val=(int, float))
     def __init__(self, **kwargs):
+        iterable_type = kwargs.get('iterable_type', None)
+        empty_allowed = kwargs.get('empty_allowed', None)
+        elements_type = kwargs.get('elements_type', None)
         min_val = kwargs.get('min_val', None)
         max_val = kwargs.get('max_val', None)
         if min_val is not None and max_val is not None and min_val > max_val:
             raise ValueError('Min value can\'t be greater than max value!')
-        empty_allowed = kwargs.get('empty_allowed', None)
-        elements_type = kwargs.get('elements_type', None)
+
         self.__checkers = {
+            IterableValidator.iterable_type_checker: [iterable_type],
             IterableValidator.empty_checker: [empty_allowed],
             IterableValidator.element_type_checker: [elements_type],
             IterableValidator.elements_min_val_checker: [min_val],

--- a/pyvalid/validators/__iterable.py
+++ b/pyvalid/validators/__iterable.py
@@ -159,18 +159,18 @@ class IterableValidator(AbstractValidator):
     @accepts(object, empty_allowed=bool, element_type=(str, int, float),
              min_val=(int, float), max_val=(int, float))
     def __init__(self, **kwargs):
-        iterable_type = kwargs.get('iterable_type', None)
-        empty_allowed = kwargs.get('empty_allowed', None)
-        elements_type = kwargs.get('elements_type', None)
         min_val = kwargs.get('min_val', None)
         max_val = kwargs.get('max_val', None)
         if min_val is not None and max_val is not None and min_val > max_val:
             raise ValueError('Min value can\'t be greater than max value!')
+        iterable_type = kwargs.get('iterable_type', None)
+        empty_allowed = kwargs.get('empty_allowed', None)
+        elements_type = kwargs.get('elements_type', None)
 
         self.__checkers = {
-            IterableValidator.iterable_type_checker: [iterable_type],
             IterableValidator.empty_checker: [empty_allowed],
             IterableValidator.element_type_checker: [elements_type],
+            IterableValidator.iterable_type_checker: [iterable_type],
             IterableValidator.elements_min_val_checker: [min_val],
             IterableValidator.elements_max_val_checker: [max_val]
         }

--- a/pyvalid/validators/__number.py
+++ b/pyvalid/validators/__number.py
@@ -67,18 +67,18 @@ class NumberValidator(AbstractValidator):
         in_range=[Iterable, Container], not_in_range=[Iterable, Container]
     )
     def __init__(self, **kwargs):
-        number_type = kwargs.get('number_type', None)
         min_val = kwargs.get('min_val', None)
         max_val = kwargs.get('max_val', None)
         if min_val is not None and max_val is not None and min_val > max_val:
             raise ValueError('Min value can\'t be greater than max value!')
+        number_type = kwargs.get('number_type', None)
         in_range = kwargs.get('in_range', None)
         not_in_range = kwargs.get('not_in_range', None)
 
         self.__checkers = {
-            NumberValidator.number_type_checker: [number_type],
             NumberValidator.min_val_checker: [min_val],
             NumberValidator.max_val_checker: [max_val],
+            NumberValidator.number_type_checker: [number_type],
             NumberValidator.in_range_checker: [in_range],
             NumberValidator.not_in_range_checker: [not_in_range]
         }

--- a/pyvalid/validators/__number.py
+++ b/pyvalid/validators/__number.py
@@ -15,6 +15,26 @@ class NumberValidator(AbstractValidator):
         number_types += (long, )  # noqa: F821
 
     @classmethod
+    def number_type_checker(cls, val, number_type):
+        """Checks if the number is of required data type.
+
+        Args:
+            val (number):
+                Tensor whose type is to be validated.
+            number_type (type):
+                Expected data type of number.
+                Ex: int, float, long.
+
+        Returns (bool):
+            True:
+                If the type of given number matches the required type.
+            False:
+                If the type of given number does not match the required type.
+
+        """
+        return type(val) == number_type
+
+    @classmethod
     def min_val_checker(cls, val, min_val):
         return val >= min_val
 
@@ -47,13 +67,16 @@ class NumberValidator(AbstractValidator):
         in_range=[Iterable, Container], not_in_range=[Iterable, Container]
     )
     def __init__(self, **kwargs):
+        number_type = kwargs.get('number_type', None)
         min_val = kwargs.get('min_val', None)
         max_val = kwargs.get('max_val', None)
         if min_val is not None and max_val is not None and min_val > max_val:
             raise ValueError('Min value can\'t be greater than max value!')
         in_range = kwargs.get('in_range', None)
         not_in_range = kwargs.get('not_in_range', None)
+
         self.__checkers = {
+            NumberValidator.number_type_checker: [number_type],
             NumberValidator.min_val_checker: [min_val],
             NumberValidator.max_val_checker: [max_val],
             NumberValidator.in_range_checker: [in_range],

--- a/tests/test_iterable_validator.py
+++ b/tests/test_iterable_validator.py
@@ -5,6 +5,18 @@ from pyvalid.validators import IterableValidator
 
 class IterableValidatorTestCase(unittest.TestCase):
 
+    def test_iterable_type(self):
+        """
+        Verify iterable_type_checker() method.
+        """
+        validator = IterableValidator(iterable_type=list)
+        self.assertTrue(validator([1, 3, 25, 14]))
+        self.assertFalse(validator({1: 'a', 2: 'b'}))
+
+        validator = IterableValidator(iterable_type=tuple)
+        self.assertTrue(validator((1, 3, 25, 14)))
+        self.assertFalse(validator([1, 3, 25, 14]))
+
     def test_empty_allowed(self):
         """
         Verify empty_checker() method.
@@ -96,7 +108,7 @@ class IterableValidatorTestCase(unittest.TestCase):
         self.assertTrue(validator([1, 3, 25, 120]))  # List
         self.assertTrue(validator((1, 3, 25, 3)))  # Tuple
         self.assertTrue(validator({1: 'pyvalid', 2: 'cython'}))  # Dictionary
-        self.assertTrue(validator((1, 3, 25, 120)))  # Set
+        self.assertTrue(validator({1, 3, 25, 120}))  # Set
         self.assertFalse(validator(8))  # Integer
         self.assertFalse(None)
 

--- a/tests/test_number_validator.py
+++ b/tests/test_number_validator.py
@@ -5,6 +5,15 @@ from pyvalid.validators import NumberValidator
 
 class NumberValidatorTestCase(unittest.TestCase):
 
+    def test_number_type(self):
+        validator = NumberValidator(number_type=int)
+        self.assertTrue(validator(12))
+        self.assertFalse(validator(10.56))
+
+        validator = NumberValidator(number_type=float)
+        self.assertTrue(validator(10.56))
+        self.assertFalse(validator(12))
+
     def test_min_val(self):
         validator = NumberValidator(min_val=-3.14)
         self.assertTrue(validator(3.14))


### PR DESCRIPTION
In NumberValidator and IterableValidator, within the iterable or number the user would expect the argument to be of a particular datatype (int, float, list, dict, etc). This type_checker provides that support