### PR TITLE
Design to support customized messages in exceptions and warnings

### DIFF
--- a/pyvalid/__exceptions.py
+++ b/pyvalid/__exceptions.py
@@ -64,17 +64,17 @@ class ArgumentValidationError(PyvalidError):
     """Raised when the function's parameter contains the value is different from the
     expected one.
     """
-    def __init__(self, func, arg_num, actual_value, allowed_arg_values):
+    def __init__(self, func, arg_num, actual_value, allowed_arg_values, msg):
         error_message_template = (
-            'The {} argument of the "{}" function is "{}" of the "{}" type, while '
-            'expected values are: "{}".'
+            'The {} argument of the "{}" function is "{}" of the "{}" type.\n{} falied. \n{}'
         )
         self.error = error_message_template.format(
             arg_num,
             self.__get_func_name__(func),
             actual_value,
             type(actual_value),
-            allowed_arg_values
+            allowed_arg_values,
+            msg
         )
 
     def __str__(self):

--- a/pyvalid/validators/__init__.py
+++ b/pyvalid/validators/__init__.py
@@ -1,4 +1,4 @@
-from pyvalid.validators.__base import AbstractValidator, Validator
+from pyvalid.validators.__base import AbstractValidator, IsValid, Validator
 from pyvalid.validators.__iterable import IterableValidator
 from pyvalid.validators.__number import NumberValidator
 from pyvalid.validators.__string import StringValidator
@@ -10,6 +10,7 @@ __all__ = [
     'is_validator',
     'Validator',
     'AbstractValidator',
+    'IsValid',
     'IterableValidator',
     'NumberValidator',
     'StringValidator',

--- a/pyvalid/validators/__number.py
+++ b/pyvalid/validators/__number.py
@@ -5,7 +5,7 @@ except ImportError:
     from collections import Iterable, Container
 
 from pyvalid import accepts
-from pyvalid.validators import AbstractValidator
+from pyvalid.validators import AbstractValidator, IsValid
 
 
 class NumberValidator(AbstractValidator):
@@ -32,31 +32,55 @@ class NumberValidator(AbstractValidator):
                 If the type of given number does not match the required type.
 
         """
-        return type(val) == number_type
+        IsValid.status = type(val) == number_type
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"expected type '{number_type}' but got '{type(val)}' instead."
+
+        return IsValid
 
     @classmethod
     def min_val_checker(cls, val, min_val):
-        return val >= min_val
+        IsValid.status = val >= min_val
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"expected '>={min_val}' but got '{val}' instead."
+
+        return IsValid
 
     @classmethod
     def max_val_checker(cls, val, max_val):
-        return val <= max_val
+        IsValid.status = val <= max_val
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"expected '<={max_val}' but got '{val}' instead."
+
+        return IsValid
 
     @classmethod
     def in_range_checker(cls, val, in_range):
-        is_valid = False
         if isinstance(in_range, Container):
-            is_valid = val in in_range
+            IsValid.status = val in in_range
         elif isinstance(in_range, Iterable):
             for item in in_range:
                 if item == val:
-                    is_valid = True
+                    IsValid.status = True
                     break
-        return is_valid
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"'{val}' must be in range '{in_range}'."
+
+        return IsValid
 
     @classmethod
     def not_in_range_checker(cls, val, not_in_range):
-        return not cls.in_range_checker(val, not_in_range)
+        in_range = cls.in_range_checker(val, not_in_range)
+        IsValid.status = not in_range.status
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"'{val}' must not be in range '{not_in_range}'."
+
+        return IsValid
 
     @property
     def checkers(self):

--- a/pyvalid/validators/__string.py
+++ b/pyvalid/validators/__string.py
@@ -5,43 +5,66 @@ except ImportError:
     from collections import Iterable, Container
 
 from pyvalid import accepts
-from pyvalid.validators import AbstractValidator
+from pyvalid.validators import AbstractValidator, IsValid
 
 
 class StringValidator(AbstractValidator):
 
     @classmethod
     def min_len_checker(cls, val, min_len):
-        return len(val) >= min_len
+        IsValid.status = len(val) >= min_len
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"expected string length to be '<={min_len}' but got length '{val}' instead."
+
+        return IsValid
 
     @classmethod
     def max_len_checker(cls, val, max_len):
-        return len(val) <= max_len
+        IsValid.status = len(val) <= max_len
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"expected string length to be '>={max_len}' but got length '{val}' instead."
+
+        return IsValid
 
     @classmethod
     def in_range_checker(cls, val, in_range):
-        is_valid = False
         if isinstance(in_range, Container):
-            is_valid = val in in_range
+            IsValid.status = val in in_range
         elif isinstance(in_range, Iterable):
             for item in in_range:
                 if item == val:
-                    is_valid = True
+                    IsValid.status = True
                     break
-        return is_valid
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"'{val}' must be in range '{in_range}'."
+
+        return IsValid
 
     @classmethod
     def not_in_range_checker(cls, val, not_in_range):
-        return not cls.in_range_checker(val, not_in_range)
+        in_range = cls.in_range_checker(val, not_in_range)
+        IsValid.status = not in_range.status
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"'{val}' must not be in range '{not_in_range}'."
+
+        return IsValid
 
     @classmethod
     def re_checker(cls, val, pattern, flags=0):
         try:
             match_obj = re.match(pattern, val, flags)
-            is_valid = match_obj is not None
+            IsValid.status = match_obj is not None
         except re.error:
-            is_valid = False
-        return is_valid
+            IsValid.status = False
+        if not IsValid.status:
+            IsValid.msg = f"In {IsValid.get_caller()}, " \
+                          f"'{val}' must not match the pattern '{pattern}'."
+
+        return IsValid
 
     @property
     def checkers(self):

--- a/tests/test_accepts.py
+++ b/tests/test_accepts.py
@@ -3,6 +3,7 @@ import unittest
 from pyvalid import ArgumentValidationError, InvalidArgumentNumberError, \
     accepts
 from pyvalid.validators import is_validator
+from pyvalid.validators import IsValid
 
 
 class AcceptsDecoratorTestCase(unittest.TestCase):
@@ -35,11 +36,13 @@ class AcceptsDecoratorTestCase(unittest.TestCase):
 
         @is_validator
         def func5_checker1(val):
-            return val == 'val1'
+            IsValid.status = val == 'val1'
+            return IsValid
 
         @is_validator
         def func5_checker2(val):
-            return val == 'val2'
+            IsValid.status = val == 'val2'
+            return IsValid
 
         @accepts(func5_checker1, [func5_checker2, 'val3', bool])
         def func5(arg1, arg2):

--- a/tests/test_iterable_validator.py
+++ b/tests/test_iterable_validator.py
@@ -10,77 +10,78 @@ class IterableValidatorTestCase(unittest.TestCase):
         Verify iterable_type_checker() method.
         """
         validator = IterableValidator(iterable_type=list)
-        self.assertTrue(validator([1, 3, 25, 14]))
-        self.assertFalse(validator({1: 'a', 2: 'b'}))
+        self.assertTrue(validator([1, 3, 25, 14]).status)
+        self.assertFalse(validator({1: 'a', 2: 'b'}).status)
 
         validator = IterableValidator(iterable_type=tuple)
-        self.assertTrue(validator((1, 3, 25, 14)))
-        self.assertFalse(validator([1, 3, 25, 14]))
+        self.assertTrue(validator((1, 3, 25, 14)).status)
+        self.assertFalse(validator([1, 3, 25, 14]).status)
 
     def test_empty_allowed(self):
         """
         Verify empty_checker() method.
         """
         validator = IterableValidator(empty_allowed=False)
-        self.assertTrue(validator([1, 3, 25, 14]))
-        self.assertFalse(validator([]))
-        self.assertFalse(None)
+        self.assertTrue(validator([1, 3, 25, 14]).status)
+        self.assertFalse(validator([]).status)
+        self.assertFalse(validator(None).status)
 
         validator = IterableValidator(empty_allowed=True)
-        self.assertTrue(validator([1, 3, 25, 14]))
-        self.assertTrue(validator([]))
-        self.assertFalse(None)
+        self.assertTrue(validator([1, 3, 25, 14]).status)
+        self.assertTrue(validator([]).status)
+        self.assertTrue(validator([]).is_warning)
+        self.assertFalse(validator(None).status)
 
     def test_elements_type(self):
         """
         Verify element_type_checker() method.
         """
         validator = IterableValidator(elements_type=int)
-        self.assertTrue(validator([1, 3, 25, 14]))
-        self.assertFalse(validator([3.56, 6.4532, 65.57, 5.546]))
-        self.assertFalse(validator(['CPython', 'PyPy', 'Jython', 'Cython']))
-        self.assertTrue(validator([]))  # Ignore empty
-        self.assertFalse(None)
+        self.assertTrue(validator([1, 3, 25, 14]).status)
+        self.assertFalse(validator([3.56, 6.4532, 65.57, 5.546]).status)
+        self.assertFalse(validator(['CPython', 'PyPy', 'Jython', 'Cython']).status)
+        self.assertTrue(validator([]).status)  # Ignore empty
+        self.assertFalse(validator(None).status)
 
         validator = IterableValidator(elements_type=float)
-        self.assertFalse(validator([1, 3, 25, 14]))
-        self.assertTrue(validator([3.56, 6.4532, 65.57, 5.546]))
-        self.assertFalse(validator(['CPython', 'PyPy', 'Jython', 'Cython']))
-        self.assertFalse(None)
+        self.assertFalse(validator([1, 3, 25, 14]).status)
+        self.assertTrue(validator([3.56, 6.4532, 65.57, 5.546]).status)
+        self.assertFalse(validator(['CPython', 'PyPy', 'Jython', 'Cython']).status)
+        self.assertFalse(validator(None).status)
 
         validator = IterableValidator(elements_type=str)
-        self.assertFalse(validator([1, 3, 25, 14]))
-        self.assertFalse(validator([3.56, 6.4532, 65.57, 5.546]))
-        self.assertTrue(validator(['CPython', 'PyPy', 'Jython', 'Cython']))
-        self.assertFalse(None)
+        self.assertFalse(validator([1, 3, 25, 14]).status)
+        self.assertFalse(validator([3.56, 6.4532, 65.57, 5.546]).status)
+        self.assertTrue(validator(['CPython', 'PyPy', 'Jython', 'Cython']).status)
+        self.assertFalse(validator(None).status)
 
     def test_min_val(self):
         """
         Verify elements_min_val_checker() method.
         """
         validator = IterableValidator(min_val=0)
-        self.assertTrue(validator([1, 3, 25, 14]))
-        self.assertFalse(validator([-1, -3, -25, -14]))
-        self.assertFalse(None)
+        self.assertTrue(validator([1, 3, 25, 14]).status)
+        self.assertFalse(validator([-1, -3, -25, -14]).status)
+        self.assertFalse(validator(None).status)
 
         validator = IterableValidator(min_val=-50.3)
-        self.assertTrue(validator([-1.6, 3.56, 25.53, -14.4]))
-        self.assertFalse(validator([-72.67, 3.56, 25.53, -14.4]))
-        self.assertFalse(None)
+        self.assertTrue(validator([-1.6, 3.56, 25.53, -14.4]).status)
+        self.assertFalse(validator([-72.67, 3.56, 25.53, -14.4]).status)
+        self.assertFalse(validator(None).status)
 
     def test_max_val(self):
         """
         Verify elements_max_val_checker() method.
         """
         validator = IterableValidator(max_val=100)
-        self.assertTrue(validator([12, 96, 24, 100]))
-        self.assertFalse(validator([104, 205, 835, 143]))
-        self.assertFalse(None)
+        self.assertTrue(validator([12, 96, 24, 100]).status)
+        self.assertFalse(validator([104, 205, 835, 143]).status)
+        self.assertFalse(validator(None).status)
 
         validator = IterableValidator(max_val=150.25)
-        self.assertTrue(validator([-154.6, 45.56, 125.53, -12.4]))
-        self.assertFalse(validator([164.67, 33.56, 110.53, -140.4]))
-        self.assertFalse(None)
+        self.assertTrue(validator([-154.6, 45.56, 125.53, -12.4]).status)
+        self.assertFalse(validator([164.67, 33.56, 110.53, -140.4]).status)
+        self.assertFalse(validator(None).status)
 
     def test_range(self):
         """
@@ -91,12 +92,12 @@ class IterableValidatorTestCase(unittest.TestCase):
             IterableValidator(min_val=100, max_val=50)
 
         validator = IterableValidator(min_val=50, max_val=100)
-        self.assertTrue(validator([60, 80, 100]))
-        self.assertTrue(validator([70, 60, 50]))
-        self.assertTrue(validator([]))
-        self.assertFalse(validator([101, 10, 10, 10]))
-        self.assertFalse(validator([-50, -25, 0]))
-        self.assertFalse(None)
+        self.assertTrue(validator([60, 80, 100]).status)
+        self.assertTrue(validator([70, 60, 50]).status)
+        self.assertTrue(validator([]).status)
+        self.assertFalse(validator([101, 10, 10, 10]).status)
+        self.assertFalse(validator([-50, -25, 0]).status)
+        self.assertFalse(validator(None).status)
 
     def test_mixed(self):
         """
@@ -105,12 +106,12 @@ class IterableValidatorTestCase(unittest.TestCase):
         validator = IterableValidator(
             empty_allowed=False, elements_type=int, min_val=-128, max_val=128
         )
-        self.assertTrue(validator([1, 3, 25, 120]))  # List
-        self.assertTrue(validator((1, 3, 25, 3)))  # Tuple
-        self.assertTrue(validator({1: 'pyvalid', 2: 'cython'}))  # Dictionary
-        self.assertTrue(validator({1, 3, 25, 120}))  # Set
-        self.assertFalse(validator(8))  # Integer
-        self.assertFalse(None)
+        self.assertTrue(validator([1, 3, 25, 120]).status)  # List
+        self.assertTrue(validator((1, 3, 25, 3)).status)  # Tuple
+        self.assertTrue(validator({1: 'pyvalid', 2: 'cython'}).status)  # Dictionary
+        self.assertTrue(validator({1, 3, 25, 120}).status)  # Set
+        self.assertFalse(validator(8).status)  # Integer
+        self.assertFalse(validator(None).status)
 
 
 if __name__ == '__main__':

--- a/tests/test_number_validator.py
+++ b/tests/test_number_validator.py
@@ -1,50 +1,51 @@
 import unittest
 
 from pyvalid.validators import NumberValidator
+from pyvalid.validators import IsValid
 
 
 class NumberValidatorTestCase(unittest.TestCase):
 
     def test_number_type(self):
         validator = NumberValidator(number_type=int)
-        self.assertTrue(validator(12))
-        self.assertFalse(validator(10.56))
+        self.assertTrue(validator(12).status)
+        self.assertFalse(validator(10.56).status)
 
         validator = NumberValidator(number_type=float)
-        self.assertTrue(validator(10.56))
-        self.assertFalse(validator(12))
+        self.assertTrue(validator(10.56).status)
+        self.assertFalse(validator(12).status)
 
     def test_min_val(self):
         validator = NumberValidator(min_val=-3.14)
-        self.assertTrue(validator(3.14))
-        self.assertTrue(validator(-3.14))
-        self.assertFalse(validator(-273.15))
-        self.assertFalse(None)
+        self.assertTrue(validator(3.14).status)
+        self.assertTrue(validator(-3.14).status)
+        self.assertFalse(validator(-273.15).status)
+        self.assertFalse(validator(None).status)
 
     def test_max_val(self):
         validator = NumberValidator(max_val=42)
-        self.assertTrue(validator(8))
-        self.assertTrue(validator(0))
-        self.assertFalse(validator(512))
-        self.assertFalse(None)
+        self.assertTrue(validator(8).status)
+        self.assertTrue(validator(0).status)
+        self.assertFalse(validator(512).status)
+        self.assertFalse(validator(None).status)
 
     def test_in_range(self):
         validator = NumberValidator(
             in_range=[2**x for x in range(16)]
         )
-        self.assertTrue(validator(1))
-        self.assertTrue(validator(256.0))
-        self.assertFalse(validator(0))
-        self.assertFalse(None)
+        self.assertTrue(validator(1).status)
+        self.assertTrue(validator(256.0).status)
+        self.assertFalse(validator(0).status)
+        self.assertFalse(validator(None).status)
 
     def test_not_in_range(self):
         validator = NumberValidator(
             not_in_range=[2**x for x in range(16)]
         )
-        self.assertTrue(validator(0))
-        self.assertTrue(validator(-1))
-        self.assertFalse(validator(2))
-        self.assertFalse(None)
+        self.assertTrue(validator(0).status)
+        self.assertTrue(validator(-1).status)
+        self.assertFalse(validator(2).status)
+        self.assertFalse(validator(None).status)
 
     def test_mixed(self):
         with self.assertRaises(ValueError):
@@ -54,12 +55,12 @@ class NumberValidatorTestCase(unittest.TestCase):
             min_val=0, max_val=2**16,
             not_in_range=[2**x for x in range(16)]
         )
-        self.assertTrue(validator(0))
-        self.assertTrue(validator(2**16 - 0.1))
-        self.assertFalse(validator(2**16 + 0.1))
-        self.assertFalse(validator(8))
-        self.assertFalse(validator(-8))
-        self.assertFalse(None)
+        self.assertTrue(validator(0).status)
+        self.assertTrue(validator(2**16 - 0.1).status)
+        self.assertFalse(validator(2**16 + 0.1).status)
+        self.assertFalse(validator(8).status)
+        self.assertFalse(validator(-8).status)
+        self.assertFalse(validator(None).status)
 
 
 if __name__ == '__main__':

--- a/tests/test_string_validator.py
+++ b/tests/test_string_validator.py
@@ -8,66 +8,66 @@ class StringValidatorTestCase(unittest.TestCase):
 
     def test_min_len(self):
         validator = StringValidator(min_len=2)
-        self.assertTrue(validator('Python'))
-        self.assertTrue(validator('Py'))
-        self.assertFalse(validator('P'))
-        self.assertFalse(validator(None))
+        self.assertTrue(validator('Python').status)
+        self.assertTrue(validator('Py').status)
+        self.assertFalse(validator('P').status)
+        self.assertFalse(validator(None).status)
 
     def test_max_len(self):
         validator = StringValidator(max_len=6)
-        self.assertTrue(validator(str()))
-        self.assertTrue(validator('Python'))
-        self.assertFalse(validator('Python3'))
-        self.assertFalse(validator(None))
+        self.assertTrue(validator(str()).status)
+        self.assertTrue(validator('Python').status)
+        self.assertFalse(validator('Python3').status)
+        self.assertFalse(validator(None).status)
 
     def test_in_range(self):
         validator = StringValidator(
             in_range=['CPython', 'PyPy', 'IronPython', 'Jython', 'Cython']
         )
-        self.assertTrue(validator('PyPy'))
-        self.assertTrue(validator('Cython'))
-        self.assertFalse(validator('Ruby'))
-        self.assertFalse(validator(None))
+        self.assertTrue(validator('PyPy').status)
+        self.assertTrue(validator('Cython').status)
+        self.assertFalse(validator('Ruby').status)
+        self.assertFalse(validator(None).status)
 
     def test_not_in_range(self):
         validator = StringValidator(
             not_in_range=['CPython', 'PyPy', 'IronPython', 'Jython', 'Cython']
         )
-        self.assertTrue(validator('Ruby'))
-        self.assertTrue(validator('Java'))
-        self.assertFalse(validator('CPython'))
-        self.assertFalse(validator(None))
+        self.assertTrue(validator('Ruby').status)
+        self.assertTrue(validator('Java').status)
+        self.assertFalse(validator('CPython').status)
+        self.assertFalse(validator(None).status)
 
     def test_re(self):
         # Allowed characters are: latin alphabet letters and digits
         validator = StringValidator(re_pattern='^[a-zA-Z0-9]+$')
-        self.assertTrue(validator('pyvalid'))
-        self.assertTrue(validator('42'))
-        self.assertFalse(validator('__pyvalid__'))
+        self.assertTrue(validator('pyvalid').status)
+        self.assertTrue(validator('42').status)
+        self.assertFalse(validator('__pyvalid__').status)
         # Regular expression is broken
         validator = StringValidator(re_pattern=':)')
-        self.assertFalse(validator('pyvalid'))
-        self.assertFalse(validator(':)'))
+        self.assertFalse(validator('pyvalid').status)
+        self.assertFalse(validator(':)').status)
         # Try to use regular expression with flag
         validator = StringValidator(
             re_pattern='^pyvalid$', re_flags=re.IGNORECASE
         )
-        self.assertTrue(validator('pyvalid'))
-        self.assertTrue(validator('PyValid'))
-        self.assertFalse(validator('42'))
-        self.assertFalse(validator(None))
+        self.assertTrue(validator('pyvalid').status)
+        self.assertTrue(validator('PyValid').status)
+        self.assertFalse(validator('42').status)
+        self.assertFalse(validator(None).status)
 
     def test_mixed(self):
         validator = StringValidator(
             min_len=6, max_len=64,
             not_in_range=['password', 'qwerty', '123456789', 'sunshine'],
         )
-        self.assertTrue(validator('Super_Mega_Strong_Password_2000'))
-        self.assertTrue(validator('_' * 6))
-        self.assertFalse(validator('_' * 3))
-        self.assertFalse(validator('_' * 128))
-        self.assertFalse(validator('sunshine'))
-        self.assertFalse(validator(None))
+        self.assertTrue(validator('Super_Mega_Strong_Password_2000').status)
+        self.assertTrue(validator('_' * 6).status)
+        self.assertFalse(validator('_' * 3).status)
+        self.assertFalse(validator('_' * 128).status)
+        self.assertFalse(validator('sunshine').status)
+        self.assertFalse(validator(None).status)
 
 
 if __name__ == '__main__':

--- a/tests/test_tensor_validator.py
+++ b/tests/test_tensor_validator.py
@@ -18,22 +18,22 @@ class TensorValidatorTestCase(unittest.TestCase):
         Verify tensor_type_checker() method.
         """
         validator = TensorValidator(tensor_type="torch.FloatTensor")
-        self.assertTrue(validator(self.t))
+        self.assertTrue(validator(self.t).status)
 
         validator = TensorValidator(tensor_type="torch.IntTensor")
-        self.assertFalse(validator(self.t))
+        self.assertFalse(validator(self.t).status)
 
     def test_dim(self):
         """
         Verify dimension_checker() method.
         """
         validator = TensorValidator(dim=2)
-        self.assertTrue(validator(self.t))
-        self.assertTrue(validator(torch.Tensor([[]])))
+        self.assertTrue(validator(self.t).status)
+        self.assertTrue(validator(torch.Tensor([[]])).status)
 
         validator = TensorValidator(dim=1)
-        self.assertFalse(validator(self.t))
-        self.assertFalse(validator(torch.Tensor([[]])))
+        self.assertFalse(validator(self.t).status)
+        self.assertFalse(validator(torch.Tensor([[]])).status)
 
     def test_empty_allowed(self):
         """
@@ -41,11 +41,12 @@ class TensorValidatorTestCase(unittest.TestCase):
         """
         validator = TensorValidator(empty_allowed=False)
         self.assertTrue(validator(self.t))
-        self.assertFalse(validator(torch.Tensor([[]])))
+        self.assertFalse(validator(torch.Tensor([[]])).status)
 
         validator = TensorValidator(empty_allowed=True)
         self.assertTrue(validator(self.t))
-        self.assertTrue(validator(torch.Tensor([[]])))
+        self.assertTrue(validator(torch.Tensor([[]])).status)
+        self.assertTrue(validator(torch.Tensor([[]])).is_warning)
 
     def test_nans_allowed(self):
         """
@@ -53,11 +54,12 @@ class TensorValidatorTestCase(unittest.TestCase):
         """
         validator = TensorValidator(nans_allowed=False)
         self.assertTrue(validator(self.t))
-        self.assertFalse(validator(torch.Tensor([np.NaN, 7.3459, 0.3454, np.NaN])))
+        self.assertFalse(validator(torch.Tensor([np.NaN, 7.3459, 0.3454, np.NaN])).status)
 
         validator = TensorValidator(nans_allowed=True)
         self.assertTrue(validator(self.t))
-        self.assertTrue(validator(torch.Tensor([np.NaN, 7.3459, 0.3454, np.NaN])))
+        self.assertTrue(validator(torch.Tensor([np.NaN, 7.3459, 0.3454, np.NaN])).status)
+        self.assertTrue(validator(torch.Tensor([np.NaN, 7.3459, 0.3454, np.NaN])).is_warning)
 
     def test_mixed(self):
         """
@@ -69,8 +71,9 @@ class TensorValidatorTestCase(unittest.TestCase):
             empty_allowed=False,
             nans_allowed=False
         )
-        self.assertTrue(validator(self.t))
-        self.assertFalse(validator([1, 2]))  # Non-tensor
+        self.assertTrue(validator(self.t).status)
+        self.assertFalse(validator([1, 2]).status)  # Non-tensor
+        self.assertFalse(validator(None).status)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently when a exception is raised, the error message does not specify which exact validation method failed. 
This code change allows the user to add customized messages to the exceptions, which also include the method name where failure occurred. 
`is_valid` variable is converted into a class called `IsValid`.

Also, user can choose to just raise warning instead of exception by setting the `is_warning` flag to True.